### PR TITLE
make validators pure functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,24 @@ All message will contain a version number of the schema.
 ```js
 const { isRoot, isRitual, isShard } = require('ssb-dark-ritual-schema')
 
-isRitual(msg)
+isRitual(ritualMessage)
 // => true
+
+isRitual(someMessage)
+// => false
+
+console.log(isRitual.errors)
+// => validation error messages
+
 ```
 
-All validators can accept either msg or msgContent
+All validators can accept either msg or msgContent.
+
+If you'd like validators to attach errors to the original message you can run them like this: 
+
+```js
+isRitual(someMessage, {attachErrors: true})
+
 
 ## Schemas
 

--- a/test/ritual.test.js
+++ b/test/ritual.test.js
@@ -1,11 +1,7 @@
 const fs = require('fs')
 const { describe } = require('tape-plus')
-
-const validator = require('is-my-json-valid')
-const schema = require('../v1/ritual/schema/ritual')
-const validate = validator(schema, { verbose: true })
-
 const { isRitual } = require('../v1/')
+const errorParser = require('../v1/lib/errorParser')
 
 describe('dark-crystal/ritual schema', context => {
   let ritual
@@ -15,39 +11,31 @@ describe('dark-crystal/ritual schema', context => {
   })
 
   context('is valid', assert => {
-    assert.ok(validate(ritual))
     assert.ok(isRitual(ritual))
 
     ritual.recps.map(recp => { return { link: recp, name: 'Bobo the Clown' } })
-    assert.ok(validate(ritual))
     assert.ok(isRitual(ritual))
   })
 
   context('invalid type', assert => {
     ritual.type = 'dark-smchystal/ritual'
-    assert.notOk(validate(ritual))
     assert.notOk(isRitual(ritual))
 
-    var errors = ritual.errors.map(e => `${e.field}: ${e.message}`)
-    assert.deepEqual(errors, ['data.type: pattern mismatch'])
+    assert.deepEqual(errorParser(isRitual), ['data.type: pattern mismatch'])
   })
 
   context('invalid version', assert => {
     ritual.version = 1
-    assert.notOk(validate(ritual))
     assert.notOk(isRitual(ritual))
 
-    var errors = ritual.errors.map(e => `${e.field}: ${e.message}`)
-    assert.deepEqual(errors, ['data.version: is the wrong type'])
+    assert.deepEqual(errorParser(isRitual), ['data.version: is the wrong type'])
   })
 
   context('invalid quorum', assert => {
     ritual.quorum = "3"
-    assert.notOk(validate(ritual))
     assert.notOk(isRitual(ritual))
 
-    var errors = ritual.errors.map(e => `${e.field}: ${e.message}`)
-    assert.deepEqual(errors, ['data.quorum: is the wrong type'])
+    assert.deepEqual(errorParser(isRitual), ['data.quorum: is the wrong type'])
 
     ritual.quorum = 3.2
     assert.notOk(isRitual(ritual))
@@ -58,11 +46,9 @@ describe('dark-crystal/ritual schema', context => {
 
   context('invalid shards', assert => {
     ritual.shards = "3"
-    assert.notOk(validate(ritual))
     assert.notOk(isRitual(ritual))
 
-    var errors = ritual.errors.map(e => `${e.field}: ${e.message}`)
-    assert.deepEqual(errors, ['data.shards: is the wrong type'])
+    assert.deepEqual(errorParser(isRitual), ['data.shards: is the wrong type'])
 
     ritual.shards = 1
     assert.notOk(isRitual(ritual))
@@ -70,19 +56,15 @@ describe('dark-crystal/ritual schema', context => {
 
   context('invalid tool', assert => {
     ritual.tool = { library: 'secrets.js' }
-    assert.notOk(validate(ritual))
     assert.notOk(isRitual(ritual))
 
-    var errors = ritual.errors.map(e => `${e.field}: ${e.message}`)
-    assert.deepEqual(errors, ['data.tool: is the wrong type'])
+    assert.deepEqual(errorParser(isRitual), ['data.tool: is the wrong type'])
   })
 
   context('invalid recps', assert => {
     ritual.recps = ['thisisnotafeedId']
-    assert.notOk(validate(ritual))
     assert.notOk(isRitual(ritual))
 
-    var errors = ritual.errors.map(e => `${e.field}: ${e.message}`)
-    assert.deepEqual(errors, ['data.recps: referenced schema does not match'])
+    assert.deepEqual(errorParser(isRitual), ['data.recps: referenced schema does not match'])
   })
 })

--- a/test/ritual.test.js
+++ b/test/ritual.test.js
@@ -20,8 +20,13 @@ describe('dark-crystal/ritual schema', context => {
   context('invalid type', assert => {
     ritual.type = 'dark-smchystal/ritual'
     assert.notOk(isRitual(ritual))
-
     assert.deepEqual(errorParser(isRitual), ['data.type: pattern mismatch'])
+  })
+
+  context('can attach errors to tested object', assert => {
+    ritual.type = 'dark-smchystal/ritual'
+    assert.notOk(isRitual(ritual, {attachErrors: true}))
+    assert.deepEqual(errorParser(ritual), ['data.type: pattern mismatch'])
   })
 
   context('invalid version', assert => {

--- a/test/root.test.js
+++ b/test/root.test.js
@@ -1,10 +1,6 @@
 const fs = require('fs')
 const { describe } = require('tape-plus')
-const validator = require('is-my-json-valid')
-const schema = require('../v1/root/schema/root')
-const validate = validator(schema, { verbose: true })
 const errorParser = require('../v1/lib/errorParser')
-
 const { isRoot } = require('../v1/')
 
 describe('dark-crystal/root schema', context => {
@@ -15,44 +11,37 @@ describe('dark-crystal/root schema', context => {
   })
 
   context('root is valid', assert => {
-    assert.ok(validate(root))
     assert.ok(isRoot(root))
 
     root.recps.map(recp => { return { link: recp, name: 'Bobo the Clown' } })
-    assert.ok(validate(root))
     assert.ok(isRoot(root))
   })
 
   context('invalid type', assert => {
     root.type = 'dark-smchystal/root'
-    assert.notOk(validate(root))
     assert.notOk(isRoot(root))
-    assert.deepEqual(['data.type: pattern mismatch'], errorParser(root))
+    assert.deepEqual(['data.type: pattern mismatch'], errorParser(isRoot))
   })
 
   context('invalid version', assert => {
     root.version = 1
-    assert.notOk(validate(root))
     assert.notOk(isRoot(root))
-    assert.deepEqual(['data.version: is the wrong type'], errorParser(root))
+    assert.deepEqual(['data.version: is the wrong type'], errorParser(isRoot))
   })
 
   context('invalid name', assert => {
     root.name = { name: 'this is my name' }
-    assert.notOk(validate(root))
     assert.notOk(isRoot(root))
-    assert.deepEqual(['data.name: is the wrong type'], errorParser(root))
+    assert.deepEqual(['data.name: is the wrong type'], errorParser(isRoot))
   })
 
   context('invalid recps', assert => {
     root.recps = [...root.recps, ...root.recps]
-    assert.notOk(validate(root))
     assert.notOk(isRoot(root))
-    assert.deepEqual(['data.recps: has more items than allowed'], errorParser(root))
+    assert.deepEqual(['data.recps: has more items than allowed'], errorParser(isRoot))
 
     root.recps = ['thisisnotafeedId']
-    assert.notOk(validate(root))
     assert.notOk(isRoot(root))
-    assert.deepEqual(['data.recps.0: no (or more than one) schemas match'], errorParser(root))
+    assert.deepEqual(['data.recps.0: no (or more than one) schemas match'], errorParser(isRoot))
   })
 })

--- a/test/shard.test.js
+++ b/test/shard.test.js
@@ -1,10 +1,7 @@
 const fs = require('fs')
 const { describe } = require('tape-plus')
-const validator = require('is-my-json-valid')
-const schema = require('../v1/shard/schema/shard')
-const validate = validator(schema, { verbose: true })
-
 const { isShard } = require('../v1/')
+const errorParser = require('../v1/lib/errorParser')
 
 describe('dark-crystal/shard schema', context => {
   let shard
@@ -14,47 +11,37 @@ describe('dark-crystal/shard schema', context => {
   })
 
   context('shard is valid', assert => {
-    assert.ok(validate(shard))
     assert.ok(isShard(shard))
     
     shard.recps.map(recp => { return { link: recp, name: 'Bobo the Clown' } })
-    assert.ok(validate(shard))
     assert.ok(isShard(shard))
   })
 
   context('invalid type', assert => {
     shard.type = 'dark-smchystal/shard'
-    assert.notOk(validate(shard))
     assert.notOk(isShard(shard))
 
-    var errors = shard.errors.map(e => `${e.field}: ${e.message}`)
-    assert.deepEqual(errors, ['data.type: pattern mismatch'])
+    assert.deepEqual(errorParser(isShard), ['data.type: pattern mismatch'])
   })
 
   context('invalid version', assert => {
     shard.version = 1
-    assert.notOk(validate(shard))
     assert.notOk(isShard(shard))
 
-    var errors = shard.errors.map(e => `${e.field}: ${e.message}`)
-    assert.deepEqual(errors, ['data.version: is the wrong type'])
+    assert.deepEqual(errorParser(isShard), ['data.version: is the wrong type'])
   })
 
   context('invalid shard', assert => {
     shard.shard = 'foo' 
-    assert.notOk(validate(shard))
     assert.notOk(isShard(shard))
 
-    var errors = shard.errors.map(e => `${e.field}: ${e.message}`)
-    assert.deepEqual(errors, ['data.shard: referenced schema does not match'])
+    assert.deepEqual(errorParser(isShard), ['data.shard: referenced schema does not match'])
   })
 
   context('invalid recps', assert => {
     shard.recps = ['thisisnotafeedId','nor is this']
-    assert.notOk(validate(shard))
     assert.notOk(isShard(shard))
 
-    var errors = shard.errors.map(e => `${e.field}: ${e.message}`)
-    assert.deepEqual(errors, ['data.recps.0: no (or more than one) schemas match', 'data.recps.1: no (or more than one) schemas match'])
+    assert.deepEqual(errorParser(isShard), ['data.recps.0: no (or more than one) schemas match', 'data.recps.1: no (or more than one) schemas match'])
   })
 })

--- a/v1/lib/validator.js
+++ b/v1/lib/validator.js
@@ -4,11 +4,12 @@ const getContent = require('ssb-msg-content')
 module.exports = function (schema) {
   const validator = Validator(schema, { verbose: true })
 
-  return function validatorWithErrors (obj) {
+  return function validatorWithErrors (obj, opts = {}) {
     const result = validator(getContent(obj))
 
     // exposes error messages provided by is-my-json-valid
     validatorWithErrors.errors = validator.errors
+    if (opts.attachErrors) obj.errors = validator.errors
 
     return result
   }

--- a/v1/lib/validator.js
+++ b/v1/lib/validator.js
@@ -1,12 +1,15 @@
-const validator = require('is-my-json-valid')
+const Validator = require('is-my-json-valid')
 const getContent = require('ssb-msg-content')
 
 module.exports = function (schema) {
-  const validate = validator(schema, { verbose: true })
+  const validator = Validator(schema, { verbose: true })
 
-  return function (obj) {
-    var result = validate(getContent(obj))
-    if (validate.errors) obj.errors = validate.errors
+  return function validatorWithErrors (obj) {
+    const result = validator(getContent(obj))
+
+    // exposes error messages provided by is-my-json-valid
+    validatorWithErrors.errors = validator.errors
+
     return result
   }
 }


### PR DESCRIPTION
yo so I'm reverting these validators to be pure functions.

I think pinning errors onto objects is quite a Railsy pattern, and I thought it could be a good idea when i saw it, but it means I can't use the validators in streams or routing in a casual way because any time `isRoot` touches anything which isn't a root at the moment, it pollutes the object by slapping errors all over it.