### PR TITLE
Add 'branch' to forward schema

### DIFF
--- a/schemas/v2/forward.js
+++ b/schemas/v2/forward.js
@@ -21,6 +21,7 @@ module.exports = {
     },
     shard: { type: 'string' },
     root: { $ref: '#/definitions/messageId' },
+    branch: { $ref: '#/definitions/branch' },
     recps: {
       type: 'array',
       maxItems: 2,

--- a/test/v2/fixtures/forward.json
+++ b/test/v2/fixtures/forward.json
@@ -3,6 +3,7 @@
   "version": "2.0.0",
   "shardVersion": "1.0.0",
   "root": "%viiJnnnXjNkfCALivEZbrDe8UndkCCCNQ/CgBOWgJLw=.sha256",
+  "branch": "%g1gbRKarJT4au9De2r4aJ+MghFSAyQzjfVnnxtJNBBw=.sha256",
   "shard": "801ad2459ecf104fb8e057106830a723dd76c8d528170786232e8b591588778a61c5cd41a81d43b23d27ac78ad152162684",
   "recps": ["@95WQAJ1XZju4YFpLib3JYdbx//BCtr5dq3bR9jPxYWs=.ed25519", "@95WQAJ1XZju4YFpLib3JYdbx//BCtr5dq3bR9jPxYWs=.ed25519"]
 }


### PR DESCRIPTION
Whether this is 'necessary' is debatable, but it adds extra cross referencing. So when we publish a forward, it looks back to the shard(s) that it's relevant too. Since we'll be publishing a forward for each shard message, it makes sense to add this assocation