### PR TITLE
add blobId as an attachment to shard

### DIFF
--- a/schemas/shard/v2.js
+++ b/schemas/shard/v2.js
@@ -23,10 +23,10 @@ module.exports = {
     },
     attachment: {
       type: 'object',
-      required: ['name', 'reference'],
+      required: ['name', 'link'],
       properties: {
         name: { type: 'string' },
-        reference: { $ref: '#/definitions/blobId' }
+        link: { $ref: '#/definitions/blobId' }
       }
     }
   },

--- a/schemas/shard/v2.js
+++ b/schemas/shard/v2.js
@@ -20,7 +20,8 @@ module.exports = {
       maxItems: 2,
       minItems: 2,
       items: { $ref: '#/definitions/feedId' }
-    }
+    },
+    attachment: { $ref: '#/definitions/blobId' }
   },
   definitions
 }

--- a/schemas/shard/v2.js
+++ b/schemas/shard/v2.js
@@ -21,7 +21,14 @@ module.exports = {
       minItems: 2,
       items: { $ref: '#/definitions/feedId' }
     },
-    attachment: { $ref: '#/definitions/blobId' }
+    attachment: {
+      type: 'object',
+      required: ['name', 'reference'],
+      properties: {
+        name: { type: 'string' },
+        reference: { $ref: '#/definitions/blobId' }
+      }
+    }
   },
   definitions
 }

--- a/test/shard/v2.json
+++ b/test/shard/v2.json
@@ -3,5 +3,9 @@
   "version": "2.0.0",
   "root": "%viiJnnnXjNkfCALivEZbrDe8UndkCCCNQ/CgBOWgJLw=.sha256",
   "shard": "Yn3foQzIrckEh139UbZ2JYuQI9FSJ3lBEV7wcePeFc/Eeo0t9kfrNp+9+bZio76RTJOM7pVEo1AUJFFupGStwNHtXmcQ9msnvnvR1RW5qLxX3luNMe+m45jcDLDCwPU237TJFIqYbUbd/DeI3YFiFH+AMU8XAPTV9scukFMVSTDrr/Li6fI=.box",
-  "recps": ["@95WQAJ1XZju4YFpLib3JYdbx//BCtr5dq3bR9jPxYWs=.ed25519", "@95WQAJ1XZju4YFpLib3JYdbx//BCtr5dq3bR9jPxYWs=.ed25519"]
+  "recps": [
+    "@95WQAJ1XZju4YFpLib3JYdbx//BCtr5dq3bR9jPxYWs=.ed25519",
+    "@95WQAJ1XZju4YFpLib3JYdbx//BCtr5dq3bR9jPxYWs=.ed25519"
+  ],
+  "attachment": "&ERGA0oJCELz2s4sr47f75iXZComB/2akzZq+IpcuqDs=.sha256"
 }

--- a/test/shard/v2.json
+++ b/test/shard/v2.json
@@ -7,5 +7,8 @@
     "@95WQAJ1XZju4YFpLib3JYdbx//BCtr5dq3bR9jPxYWs=.ed25519",
     "@95WQAJ1XZju4YFpLib3JYdbx//BCtr5dq3bR9jPxYWs=.ed25519"
   ],
-  "attachment": "&ERGA0oJCELz2s4sr47f75iXZComB/2akzZq+IpcuqDs=.sha256"
+  "attachment": {
+    "name": "gossip.json",
+    "reference": "&ERGA0oJCELz2s4sr47f75iXZComB/2akzZq+IpcuqDs=.sha256"
+  }
 }

--- a/test/shard/v2.json
+++ b/test/shard/v2.json
@@ -9,6 +9,6 @@
   ],
   "attachment": {
     "name": "gossip.json",
-    "reference": "&ERGA0oJCELz2s4sr47f75iXZComB/2akzZq+IpcuqDs=.sha256"
+    "link": "&ERGA0oJCELz2s4sr47f75iXZComB/2akzZq+IpcuqDs=.sha256"
   }
 }

--- a/test/shard/v2.test.js
+++ b/test/shard/v2.test.js
@@ -42,4 +42,10 @@ describe('dark-crystal/shard v2 schema', context => {
 
     assert.deepEqual(errorParser(isShard), [ 'data.recps.0: referenced schema does not match', 'data.recps.1: referenced schema does not match' ])
   })
+
+  context('invalid attachment blob reference', assert => {
+    shard.attachment = 'not a blobId'
+    assert.notOk(isShard(shard))
+    assert.deepEqual(errorParser(isShard), [ 'data.attachment: referenced schema does not match' ])
+  })
 })

--- a/test/shard/v2.test.js
+++ b/test/shard/v2.test.js
@@ -47,11 +47,11 @@ describe('dark-crystal/shard v2 schema', context => {
   })
 
   context('invalid attachment blob reference', assert => {
-    shard.attachment = { name: 123.45, reference: "not a blobId" }
+    shard.attachment = { name: 123.45, link: "not a blobId" }
     assert.notOk(isShard(shard))
     assert.deepEqual(errorParser(isShard), [
       'data.attachment.name: is the wrong type',
-      'data.attachment.reference: referenced schema does not match'
+      'data.attachment.link: referenced schema does not match'
     ])
   })
 })

--- a/test/shard/v2.test.js
+++ b/test/shard/v2.test.js
@@ -40,12 +40,18 @@ describe('dark-crystal/shard v2 schema', context => {
     shard.recps = ['thisisnotafeedId', 'nor is this']
     assert.notOk(isShard(shard))
 
-    assert.deepEqual(errorParser(isShard), [ 'data.recps.0: referenced schema does not match', 'data.recps.1: referenced schema does not match' ])
+    assert.deepEqual(errorParser(isShard), [
+      'data.recps.0: referenced schema does not match',
+      'data.recps.1: referenced schema does not match'
+    ])
   })
 
   context('invalid attachment blob reference', assert => {
-    shard.attachment = 'not a blobId'
+    shard.attachment = { name: 123.45, reference: "not a blobId" }
     assert.notOk(isShard(shard))
-    assert.deepEqual(errorParser(isShard), [ 'data.attachment: referenced schema does not match' ])
+    assert.deepEqual(errorParser(isShard), [
+      'data.attachment.name: is the wrong type',
+      'data.attachment.reference: referenced schema does not match'
+    ])
   })
 })


### PR DESCRIPTION
Adds capacity to attach a file / blob reference to a shard message. Needed by Patchwork Integration - Phase 1: https://github.com/ssbc/patchwork/issues/952